### PR TITLE
Remove 'Individual' package type and related functionality

### DIFF
--- a/app/Actions/CancelInvitation.php
+++ b/app/Actions/CancelInvitation.php
@@ -5,7 +5,7 @@ namespace App\Actions;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 
-class Cancelnvitation
+class CancelInvitation
 {
     /**
      * Cancel the given team invitation.

--- a/app/Enums/PackageType.php
+++ b/app/Enums/PackageType.php
@@ -8,14 +8,12 @@ use Filament\Support\Contracts\HasLabel;
 enum PackageType: string implements HasIcon, HasLabel
 {
     case Composer = 'composer';
-    case Individual = 'individual';
     case Github = 'github';
 
     public function getLabel(): ?string
     {
         return match ($this) {
             self::Composer => 'Composer',
-            self::Individual => 'Individual',
             self::Github => 'GitHub',
         };
     }
@@ -24,7 +22,6 @@ enum PackageType: string implements HasIcon, HasLabel
     {
         return match ($this) {
             self::Composer => 'heroicon-o-archive-box',
-            self::Individual => 'heroicon-o-at-symbol',
             self::Github => 'icon-github',
         };
     }

--- a/app/Filament/Pages/AcceptInvitation.php
+++ b/app/Filament/Pages/AcceptInvitation.php
@@ -3,7 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Actions\AddTeamMember;
-use App\Actions\Cancelnvitation;
+use App\Actions\CancelInvitation;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use Filament\Actions\Action;
@@ -111,7 +111,7 @@ class AcceptInvitation extends SimplePage
             ]
         );
 
-        app(Cancelnvitation::class)->cancel($this->invitation);
+        app(CancelInvitation::class)->cancel($this->invitation);
 
         $this->redirect(Filament::getUrl($this->invitation->team));
     }

--- a/app/Filament/Pages/Tenancy/EditTeam.php
+++ b/app/Filament/Pages/Tenancy/EditTeam.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\Pages\Tenancy;
 
-use App\Actions\Cancelnvitation;
+use App\Actions\CancelInvitation;
 use App\Actions\InviteTeamMember;
 use App\Actions\RemoveTeamMember;
 use App\Models\TeamInvitation;
@@ -113,7 +113,7 @@ class EditTeam extends EditTenantProfile
                                             ->link()
                                             ->requiresConfirmation()
                                             ->action(
-                                                fn (TeamInvitation $record) => app(Cancelnvitation::class)->cancel($record)
+                                                fn (TeamInvitation $record) => app(CancelInvitation::class)->cancel($record)
                                             ),
                                     ])
                                     ->alignEnd(),

--- a/app/Filament/Resources/PackageResource/Forms/PackageResourceForm.php
+++ b/app/Filament/Resources/PackageResource/Forms/PackageResourceForm.php
@@ -21,7 +21,6 @@ abstract class PackageResourceForm
                     ->columns(2)
                     ->schema([
                         static::getComposerInstructionsFormComponent(),
-                        static::getIndividualInstructionsFormComponent(),
                         static::getGithubInstructionsFormComponent(),
                         static::getUrlFormComponent()->columnSpan(2),
                         static::getUsernameFormComponent(),
@@ -39,7 +38,6 @@ abstract class PackageResourceForm
                     ->columns(2)
                     ->schema([
                         static::getComposerInstructionsFormComponent(),
-                        static::getIndividualInstructionsFormComponent(),
                         static::getGithubInstructionsFormComponent(),
                         static::getUrlFormComponent()->columnSpan(2),
                         static::getUsernameFormComponent(),
@@ -54,7 +52,6 @@ abstract class PackageResourceForm
             ->label(
                 fn (Forms\Get $get) => match (PackageType::of($get('type'))) {
                     PackageType::Composer => 'vendor/package',
-                    PackageType::Individual => 'Nome do Produto',
                     PackageType::Github => 'user/repo',
                 }
             )
@@ -98,14 +95,6 @@ abstract class PackageResourceForm
             ->visible(fn (Forms\Get $get): bool => enum_equals($get('type'), PackageType::Composer));
     }
 
-    public static function getIndividualInstructionsFormComponent(): Forms\Components\Component
-    {
-        return Forms\Components\Placeholder::make('individual-instructions')
-            ->label('Configurações Individuais')
-            ->content('Para adicionar um pacote do tipo Individual, você deve informar as credenciais de acesso ao produto. Cada membro do time receberá uma credencial de acesso individual. Não compartilhe essas credenciais com ninguém.')
-            ->visible(fn (Forms\Get $get): bool => enum_equals($get('type'), PackageType::Individual));
-    }
-
     public static function getGithubInstructionsFormComponent(): Forms\Components\Component
     {
         return Forms\Components\Placeholder::make('github-instructions')
@@ -120,7 +109,6 @@ abstract class PackageResourceForm
             ->label(
                 fn (Forms\Get $get) => match (PackageType::of($get('type'))) {
                     PackageType::Composer => 'URL do Repositório Composer',
-                    PackageType::Individual => 'URL do Produto',
                     PackageType::Github => 'URL SSH do Repositório',
                 }
             )
@@ -146,7 +134,6 @@ abstract class PackageResourceForm
             ->label(
                 fn (Forms\Get $get) => match (PackageType::of($get('type'))) {
                     PackageType::Composer => 'Username do Composer',
-                    PackageType::Individual => 'Email de Acesso',
                     PackageType::Github => 'Username ou Organização do GitHub',
                 }
             )
@@ -159,7 +146,6 @@ abstract class PackageResourceForm
             ->label(
                 fn (Forms\Get $get) => match (PackageType::of($get('type'))) {
                     PackageType::Composer => 'Password do Composer',
-                    PackageType::Individual => 'Senha de Acesso',
                     PackageType::Github => 'Personal Access Token (PAT)',
                 }
             )

--- a/app/Filament/Resources/PackageResource/Pages/ListPackageVersions.php
+++ b/app/Filament/Resources/PackageResource/Pages/ListPackageVersions.php
@@ -61,9 +61,12 @@ class ListPackageVersions extends ViewRecord
 
     private function getVersions(): array
     {
-        return Cache::remember("package-{$this->record->id}-versions", now()->addMinutes(30), function (): array {
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        return Cache::remember("user-{$user->id}-package-{$this->record->id}-versions", now()->addMinutes(30), function () use ($user): array{
             $file = rescue(
-                fn (): array => app(Filesystem::class)->json(storage_path("app/private/satis/p2/{$this->record->name}.json")),
+                fn (): array => app(Filesystem::class)->json(storage_path("app/private/satis/{$user->id}/p2/{$this->record->name}.json")),
                 fn (): array => []
             );
 

--- a/app/Filament/Resources/PackageResource/Pages/ManagePackages.php
+++ b/app/Filament/Resources/PackageResource/Pages/ManagePackages.php
@@ -51,27 +51,17 @@ class ManagePackages extends ManageRecords
                             ->schema([
                                 Infolists\Components\TextEntry::make('url')
                                     ->label(
-                                        fn (Package $record) => match ($record->type) {
-                                            PackageType::Composer => 'URL do Repositório',
-                                            PackageType::Individual => 'URL do Produto',
-                                            PackageType::Github => 'URL do Repositório',
-                                        }
+                                        fn (Package $record) => 'URL do Repositório'
                                     )
                                     ->copyable(),
 
                                 Infolists\Components\TextEntry::make('username')
                                     ->label(
-                                        fn (Package $record) => match ($record->type) {
-                                            PackageType::Individual => 'Email',
-                                            default => 'Username',
-                                        }
+                                        fn (Package $record) => 'Username'
                                     )
                                     ->copyable()
                                     ->getStateUsing(
-                                        fn (Package $record) => match ($record->type) {
-                                            PackageType::Individual => $record->username,
-                                            default => '[Redacted]',
-                                        }
+                                        fn (Package $record) => '[Redacted]'
                                     ),
 
                                 Infolists\Components\TextEntry::make('password')
@@ -83,10 +73,7 @@ class ManagePackages extends ManageRecords
                                     )
                                     ->copyable()
                                     ->getStateUsing(
-                                        fn (Package $record) => match ($record->type) {
-                                            PackageType::Individual => $record->password,
-                                            default => '[Redacted]',
-                                        }
+                                        fn (Package $record) => '[Redacted]'
                                     ),
                             ])
                             ->headerActions([
@@ -131,12 +118,6 @@ class ManagePackages extends ManageRecords
                                     ->url(
                                         url: fn (Package $record) => PackageResource::getUrl(name: 'versions', parameters: ['record' => $record]),
                                         shouldOpenInNewTab: true,
-                                    )
-                                    ->visible(
-                                        fn (Package $record) => match ($record->type) {
-                                            PackageType::Individual => false,
-                                            default => true,
-                                        }
                                     ),
                             ]),
                     ]),

--- a/app/Filament/Resources/PackageResource/Pages/ManagePackages.php
+++ b/app/Filament/Resources/PackageResource/Pages/ManagePackages.php
@@ -50,19 +50,12 @@ class ManagePackages extends ManageRecords
                             ->columns(3)
                             ->schema([
                                 Infolists\Components\TextEntry::make('url')
-                                    ->label(
-                                        fn (Package $record) => 'URL do Repositório'
-                                    )
+                                    ->label('URL do Repositório')
                                     ->copyable(),
 
                                 Infolists\Components\TextEntry::make('username')
-                                    ->label(
-                                        fn (Package $record) => 'Username'
-                                    )
-                                    ->copyable()
-                                    ->getStateUsing(
-                                        fn (Package $record) => '[Redacted]'
-                                    ),
+                                    ->label('Username')
+                                    ->getStateUsing('[Redacted]'),
 
                                 Infolists\Components\TextEntry::make('password')
                                     ->label(
@@ -71,10 +64,7 @@ class ManagePackages extends ManageRecords
                                             default => 'Senha',
                                         }
                                     )
-                                    ->copyable()
-                                    ->getStateUsing(
-                                        fn (Package $record) => '[Redacted]'
-                                    ),
+                                    ->getStateUsing('[Redacted]'),
                             ])
                             ->headerActions([
                                 Infolists\Components\Actions\Action::make('edit')

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "laravel/horizon": "^5.31",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.10.1",
-        "livewire/flux-pro": "^2.0",
         "livewire/livewire": "^3.0",
         "shweshi/opengraph": "^1.0",
         "staudenmeir/eloquent-has-many-deep": "^1.21"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9479c1a233da759c17f06e59a1dd324a",
+    "content-hash": "26a37fe30162fee8440a0cb98b7332e5",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -3997,125 +3997,6 @@
                 }
             ],
             "time": "2024-12-08T08:18:47+00:00"
-        },
-        {
-            "name": "livewire/flux",
-            "version": "v2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/livewire/flux.git",
-                "reference": "a635c8440199e1838ba800a82279e6729a9e5e8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/a635c8440199e1838ba800a82279e6729a9e5e8c",
-                "reference": "a635c8440199e1838ba800a82279e6729a9e5e8c",
-                "shasum": ""
-            },
-            "require": {
-                "illuminate/console": "^10.0|^11.0|^12.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
-                "illuminate/view": "^10.0|^11.0|^12.0",
-                "laravel/prompts": "^0.1|^0.2|^0.3",
-                "livewire/livewire": "^3.5.19",
-                "php": "^8.1",
-                "symfony/console": "^6.0|^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Flux": "Flux\\Flux"
-                    },
-                    "providers": [
-                        "Flux\\FluxServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Flux\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "proprietary"
-            ],
-            "authors": [
-                {
-                    "name": "Caleb Porzio",
-                    "email": "calebporzio@gmail.com"
-                }
-            ],
-            "description": "The official UI component library for Livewire.",
-            "keywords": [
-                "components",
-                "flux",
-                "laravel",
-                "livewire",
-                "ui"
-            ],
-            "support": {
-                "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.0.5"
-            },
-            "time": "2025-03-09T19:33:12+00:00"
-        },
-        {
-            "name": "livewire/flux-pro",
-            "version": "2.0.5",
-            "dist": {
-                "type": "zip",
-                "url": "https://satis.test/archives/livewire/flux-pro/livewire-flux-pro-b9a4bdbf6963880d82bc3605e6d4489a60cf2480-zip.zip",
-                "shasum": "a0cadf37ae2ea1b0c026f08570105fadc2e58cf2"
-            },
-            "require": {
-                "illuminate/console": "^10.0|^11.0|^12.0",
-                "illuminate/support": "^10.0|^11.0|^12.0",
-                "illuminate/view": "^10.0|^11.0|^12.0",
-                "laravel/prompts": "^0.1.24|^0.2|^0.3",
-                "livewire/flux": "2.0.5|dev-main",
-                "livewire/livewire": "^3.5.19",
-                "php": "^8.1",
-                "symfony/console": "^6.0|^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "aliases": {
-                        "Flux": "FluxPro\\FluxPro"
-                    },
-                    "providers": [
-                        "FluxPro\\FluxProServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/helpers.php"
-                ],
-                "psr-4": {
-                    "FluxPro\\": "src/"
-                }
-            },
-            "license": [
-                "proprietary"
-            ],
-            "authors": [
-                {
-                    "name": "Caleb Porzio",
-                    "email": "calebporzio@gmail.com"
-                }
-            ],
-            "description": "The pro version of Flux, the official UI component library for Livewire.",
-            "keywords": [
-                "components",
-                "flux",
-                "laravel",
-                "livewire",
-                "ui"
-            ],
-            "time": "2025-03-09T19:37:02+00:00"
         },
         {
             "name": "livewire/livewire",


### PR DESCRIPTION
This commit eliminates support for the 'Individual' package type, including its form components, labels, and visibility conditions. Additionally, fixes typos in the CancelInvitation action class and updates dependencies to remove 'livewire/flux-pro'. These changes simplify the codebase and focus on remaining supported package types.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Atualize "[ ]" para "[x]" para marcar uma caixa) -->

**Que tipo de alteração essa PR adiciona?** (Marque pelo menos Um)

- [x] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Outro, por favor descreva:

**Este PR apresenta uma mudança significativa?** (Marque um)

- [x] Sim
- [ ] Não

#18 